### PR TITLE
Missing function `toggle-read-only`

### DIFF
--- a/breadcrumb.el
+++ b/breadcrumb.el
@@ -740,6 +740,15 @@ If POS is nil, use current buffer location."
     (bury-buffer))
 )
 
+(defun toggle-read-only (f)
+  "Toggle the read-only status of the current buffer based on the
+value of f. If f is 1, make the buffer read-only. If f is 0,
+make the buffer writable."
+  (interactive "P")
+  (if (equal f 0)
+      (read-only-mode -1)
+    (read-only-mode 1)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 


### PR DESCRIPTION
There seems to be a missing function called `toggle-read-only` that's used in several places throughout the codebase. Not sure if this was once support in a previous version of emacs or a dependent package, but in the version that I am using (29.3) it is not available.

I've added a simple implementation to make the code work.